### PR TITLE
[TASK] Add a Validator to check if an email is a member of a given list

### DIFF
--- a/Classes/Wwwision/Neos/MailChimp/Domain/Service/MailChimpService.php
+++ b/Classes/Wwwision/Neos/MailChimp/Domain/Service/MailChimpService.php
@@ -72,6 +72,29 @@ class MailChimpService {
 	/**
 	 * @param string $listId
 	 * @param string $emailAddress
+	 * @return boolean
+	 */
+	public function isMember($listId, $emailAddress) {
+		try {
+			$members = $this->getMemberInfo($listId, $emailAddress);
+			return $members['success_count'] > 0;
+		} catch (\Exception $exception) {
+			return FALSE;
+		}
+	}
+
+	/**
+	 * @param string $listId
+	 * @param string $emailAddress
+	 * @return array
+	 */
+	public function getMemberInfo($listId, $emailAddress) {
+		return $this->mailChimpClient->lists->memberInfo($listId, array(array('email' => $emailAddress)));
+	}
+
+	/**
+	 * @param string $listId
+	 * @param string $emailAddress
 	 * @return void
 	 */
 	public function subscribe($listId, $emailAddress) {

--- a/Classes/Wwwision/Neos/MailChimp/Validation/Validator/UniqueSubscriptionValidator.php
+++ b/Classes/Wwwision/Neos/MailChimp/Validation/Validator/UniqueSubscriptionValidator.php
@@ -1,0 +1,48 @@
+<?php
+namespace Wwwision\Neos\MailChimp\Validation\Validator;
+
+/*                                                                          *
+ * This script belongs to the TYPO3 Flow package "Wwwision.Neos.MailChimp". *
+ *                                                                          *
+ *                                                                          */
+
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Validation\Validator\EmailAddressValidator;
+use Wwwision\Neos\MailChimp\Domain\Service\MailChimpService;
+
+/**
+ * Validator for email addresses
+ *
+ * @api
+ * @Flow\Scope("singleton")
+ */
+class UniqueSubscriptionValidator extends EmailAddressValidator {
+
+	/**
+	 * @Flow\Inject
+	 * @var MailChimpService
+	 */
+	protected $mailChimpService;
+
+	/**
+	 * @var array
+	 */
+	protected $supportedOptions = array(
+		'listId' => array(NULL, 'MailChimp List ID', 'string', TRUE)
+	);
+
+	/**
+	 * Checks if the given value is a valid email address.
+	 *
+	 * @param mixed $value The value that should be validated
+	 * @return void
+	 * @api
+	 */
+	protected function isValid($value) {
+		$options = $this->getOptions();
+		if ($this->validEmail($value) && $this->mailChimpService->isMember($options['listId'], $value)) {
+			$this->addError('This email address is already registered in our newsletter.', 1422317184);
+		}
+	}
+
+}

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -19,6 +19,10 @@ TYPO3:
           'Wwwision.Neos.MailChimp:MailChimpSubscriptionFinisher':
             implementationClassName: 'Wwwision\Neos\MailChimp\Form\Finishers\MailChimpSubscriptionFinisher'
 
+        validatorPresets:
+          'Wwwision.Neos.MailChimp:UniqueSubscription':
+            implementationClassName: 'Wwwision\Neos\MailChimp\Validation\Validator\UniqueSubscriptionValidator'
+
         formElementTypes:
           'TYPO3.Form:Form':
             formBuilder:

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ renderables:
                         identifier: 'TYPO3.Flow:NotEmpty'
                     -
                         identifier: 'TYPO3.Flow:EmailAddress'
+					-
+						identifier: 'Wwwision.Neos.MailChimp:UniqueSubscription'
+						options:
+						  listId: '<MAILCHIMP-LIST-ID>'
                 properties:
                     placeholder: 'Your email address'
                 defaultValue: ''


### PR DESCRIPTION
This change add a new Validator class to check if the current email address
is a member of the given list. This is useful has MailChimp API will throw
an exception if we try to subscribe the same email address more than one
time.