### PR TITLE
BUGFIX: Don't complain about "formBuilder" configuration

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -12,6 +12,10 @@ TYPO3:
         'mailchimp.mailchimp': ['.*']
 
   Form:
+    supertypeResolver:
+      hiddenProperties:
+        # don't complain about "formBuilder" settings, if the TYPO3.FormBuilder package is not installed
+        formBuilder: formBuilder
     presets:
       'default':
         finisherPresets:


### PR DESCRIPTION
Adds ``formBuilder`` to the list of "hiddenProperties" in order
to avoid exceptions when the ``TYPO3.FormBuilder`` package is not installed.

Fixes: #7