### PR TITLE
BUGFIX: Don't require "additionalFields" in MailChimpSubscriptionFini…

### DIFF
--- a/Classes/Wwwision/Neos/MailChimp/Form/Finishers/MailChimpSubscriptionFinisher.php
+++ b/Classes/Wwwision/Neos/MailChimp/Form/Finishers/MailChimpSubscriptionFinisher.php
@@ -26,7 +26,7 @@ class MailChimpSubscriptionFinisher extends AbstractFinisher
     protected $defaultOptions = [
         'listId' => '',
         'emailAddress' => '{email}',
-        'additionalFields' => []
+        'additionalFields' => null
     ];
 
     /**
@@ -57,6 +57,9 @@ class MailChimpSubscriptionFinisher extends AbstractFinisher
      */
     protected function replacePlaceholders($field)
     {
+        if ($field === null) {
+            return null;
+        }
         if (is_array($field)) {
             return array_map([$this, 'replacePlaceholders'], $field);
         }


### PR DESCRIPTION
…sher

Previously the `additionalFields` (sent as `merge_fields` to the API) defaulted
to an empty `array`. With this fix the fields are only sent if specified.

This fixes the same issue as in #11 but for version 3.x of the package