### PR TITLE
Add optional marketing_permissions parameter

### DIFF
--- a/Classes/Wwwision/Neos/MailChimp/Domain/Service/MailChimpService.php
+++ b/Classes/Wwwision/Neos/MailChimp/Domain/Service/MailChimpService.php
@@ -120,9 +120,10 @@ class MailChimpService
      * @param string $listId
      * @param string $emailAddress
      * @param array $additionalFields
+     * @param array $marketingPermissions
      * @return void
      */
-    public function subscribe($listId, $emailAddress, array $additionalFields = null)
+    public function subscribe($listId, $emailAddress, array $additionalFields = null, array $marketingPermissions = null)
     {
         $subscriberHash = md5(strtolower($emailAddress));
         $arguments = [
@@ -131,6 +132,9 @@ class MailChimpService
         ];
         if ($additionalFields !== null) {
             $arguments['merge_fields'] = $additionalFields;
+        }
+        if ($marketingPermissions !== null) {
+            $arguments['marketing_permissions'] = $marketingPermissions;
         }
         $this->put("lists/$listId/members/$subscriberHash", $arguments);
     }


### PR DESCRIPTION
Example usage

```php
$this->mailChimpService->subscribe(
  '<mailchimp_list_id>',
  'mail@example.com',
  [
    'FNAME' => 'My Firstname',
    'LNAME' => 'My Lastname'
  ],
  [
     [
        'marketing_permission_id' => '<marketing_permission_id>',
        'enabled' => true
     ]
  ]
);
```

How to get the `marketing_permission_id`?

Currently the marketing_permission_id s are only available via API, using MailChimps API playground is probably the easiest way to get the IDs.

See #17 