### PR TITLE
Show only subscribed member for  list & fix count

### DIFF
--- a/Classes/Wwwision/Neos/MailChimp/Domain/Service/MailChimpService.php
+++ b/Classes/Wwwision/Neos/MailChimp/Domain/Service/MailChimpService.php
@@ -97,10 +97,15 @@ class MailChimpService
     {
         $memberQuery = new CallbackQuery(function (CallbackQuery $query) use ($listId) {
             $members = $this->get("lists/$listId/members", ['offset' => $query->getOffset(), 'count' => $query->getLimit()]);
-            return $members['members'];
+            return array_filter(
+                $members['members'],
+                static function (array $member) {
+                    return $member['status'] === 'subscribed';
+                }
+            );
         }, function () use ($listId) {
-            $members = $this->get("lists/$listId/members", ['count' => 0]);
-            return (integer)$members['total_items'];
+            $list = $this->get("lists/$listId");
+            return (integer)$list['stats']['member_count'];
         });
         return $memberQuery->execute();
     }


### PR DESCRIPTION
This fixes the discrepancy between the "Number of members" being less
than the members actually listed (because the list also showed pending
members.)

The count callback is adjusted, too, to make sure the pagination is
working correctly.