### PR TITLE
BUGFIX: Make compatible with Neos 7.3

### DIFF
--- a/Classes/Wwwision/Neos/MailChimp/Validation/Validator/UniqueSubscriptionValidator.php
+++ b/Classes/Wwwision/Neos/MailChimp/Validation/Validator/UniqueSubscriptionValidator.php
@@ -25,7 +25,9 @@ class UniqueSubscriptionValidator extends EmailAddressValidator
      * @var array
      */
     protected $supportedOptions = [
-        'listId' => [null, 'MailChimp List ID', 'string', true]
+        'listId' => [null, 'MailChimp List ID', 'string', true],
+        'strict' => [false, 'Whether to fail validation on RFC warnings', 'bool'],
+        'checkDns' => [false, 'Whether to use DNS checks', 'bool']
     ];
 
     /**


### PR DESCRIPTION
This change prevents a php error that is thrown in the parent class `EmailAddressValidator` because of a missing array key.